### PR TITLE
Upsamples batch for all models (including SingleBatch)

### DIFF
--- a/R/methods-MixtureModel.R
+++ b/R/methods-MixtureModel.R
@@ -828,8 +828,8 @@ setReplaceMethod("marginal_lik", c("MixtureModel", "numeric"),
 
 
 #' @rdname tile-functions
-#' @aliases upSample,MultiBatchModel-method
-setMethod("upSample", "MultiBatchModel", function(model, tiles){
+#' @aliases upSample,MixtureModel-method
+setMethod("upSample", "MixtureModel", function(model, tiles){
   tile.sum <- tileSummaries(tiles)
   ##stopifnot(all.equal(y(model), tile.sum$avgLRR))
   key <- match(tiles$tile, tile.sum$tile)
@@ -840,20 +840,5 @@ setMethod("upSample", "MultiBatchModel", function(model, tiles){
   probz(model2) <- probs2 * (iter(model) - 1)
   z(model2) <- z(model)[key]
   batch(model2) <- tiles$batch
-  model2
-})
-
-#' @rdname tile-functions
-#' @aliases upSample,MixtureModel-method
-setMethod("upSample", "MixtureModel", function(model, tiles){
-  tile.sum <- tileSummaries(tiles)
-  ##stopifnot(all.equal(y(model), tile.sum$avgLRR, tolerance=0.1, scale=1))
-  key <- match(tiles$tile, tile.sum$tile)
-  model2 <- model
-  y(model2) <- tiles$logratio
-  probs <- probz(model)
-  probs2 <- probs[key, , drop=FALSE]
-  probz(model2) <- probs2 * (iter(model) - 1)
-  z(model2) <- z(model)[key]
   model2
 })

--- a/man/tile-functions.Rd
+++ b/man/tile-functions.Rd
@@ -6,7 +6,6 @@
 \alias{upSample}
 \alias{tileMedians}
 \alias{tileSummaries}
-\alias{upSample,MultiBatchModel-method}
 \alias{upSample,MixtureModel-method}
 \title{Create tile labels for each observation}
 \usage{
@@ -15,8 +14,6 @@ upSample(model, tiles)
 tileMedians(y, nt, batch)
 
 tileSummaries(tiles)
-
-\S4method{upSample}{MultiBatchModel}(model, tiles)
 
 \S4method{upSample}{MixtureModel}(model, tiles)
 }


### PR DESCRIPTION
Could batch upsampling be applied for all models? `z`, `data`, `batch`, and `probz` are the only slots whose dimensions depend on the length of the data vector. `batchElements` values could also be updated, but since it doesn't have an accessor function, I suppose it's not intended as public.

Upsampled batch IDs in a SingleBatchModel could be useful if it is used to create a new model later on.

I didn't add any validation or assert-style checks for comparing lengths in the new model. If the tibble is mismatched, the new vectors and `probz` matrix should be sized correctly, albeit w/NA values.